### PR TITLE
fix: return empty array instead of null for documents list

### DIFF
--- a/backend/internal/api/handlers/documents.go
+++ b/backend/internal/api/handlers/documents.go
@@ -56,7 +56,7 @@ func (h *DocumentHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var docs []DocumentListItem
+	docs := make([]DocumentListItem, 0)
 	for name, info := range sess.DocumentRegistry {
 		facts, _ := h.store.LoadDocumentFacts(sessionID, name)
 


### PR DESCRIPTION
## Why
The documents list endpoint returns JSON `null` instead of `[]` when a session has no documents, crashing the frontend session page.

## What
- Initialize `docs` slice with `make()` so JSON serialization produces `[]` instead of `null`

## Risk Assessment
Low — one-line fix to a nil slice initialization, no behavioral change for non-empty lists.

Generated with Amp