### PR TITLE
feat: add conversation history context to query processor

### DIFF
--- a/backend/internal/api/handlers/query.go
+++ b/backend/internal/api/handlers/query.go
@@ -109,6 +109,11 @@ func (h *QueryHandler) Submit(w http.ResponseWriter, r *http.Request) {
 	chunkManager.LoadChunks() // Load chunks for context retrieval
 	processor := query.NewProcessor(claudeClient, chunkManager, facts)
 
+	// Pass conversation history so follow-up questions work
+	if hist := h.history[sessionID]; len(hist) > 0 {
+		processor.SetConversationHistory(h.buildConversationHistory(sessionID))
+	}
+
 	// Process query with Claude
 	ctx := context.Background()
 	maxPasses := req.MaxPasses
@@ -285,6 +290,11 @@ func (h *QueryHandler) SubmitStream(w http.ResponseWriter, r *http.Request) {
 	chunkManager.LoadChunks()
 	processor := query.NewProcessor(claudeClient, chunkManager, facts)
 
+	// Pass conversation history so follow-up questions work
+	if hist := h.history[sessionID]; len(hist) > 0 {
+		processor.SetConversationHistory(h.buildConversationHistory(sessionID))
+	}
+
 	// Set progress callback to stream batch updates
 	processor.SetProgressCallback(func(progress query.BatchProgress) {
 		sendEvent("progress", progress)
@@ -452,6 +462,25 @@ func (h *QueryHandler) History(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, history)
+}
+
+// buildConversationHistory converts in-memory query history to conversation turns for the processor.
+// Limits to the last 10 turns to keep prompts reasonable.
+func (h *QueryHandler) buildConversationHistory(sessionID string) []query.ConversationTurn {
+	hist := h.history[sessionID]
+	// Take at most the last 10 turns
+	start := 0
+	if len(hist) > 10 {
+		start = len(hist) - 10
+	}
+	turns := make([]query.ConversationTurn, 0, len(hist)-start)
+	for _, entry := range hist[start:] {
+		turns = append(turns, query.ConversationTurn{
+			Query:  entry.Query,
+			Answer: entry.Answer,
+		})
+	}
+	return turns
 }
 
 // findQuoteWithNormalizedWhitespace finds a quote in text by normalizing whitespace.

--- a/backend/internal/services/query/processor.go
+++ b/backend/internal/services/query/processor.go
@@ -23,17 +23,29 @@ type BatchProgress struct {
 // ProgressCallback is called to report query progress
 type ProgressCallback func(BatchProgress)
 
+// ConversationTurn represents a prior question and answer in the conversation
+type ConversationTurn struct {
+	Query  string
+	Answer string
+}
+
 // Processor handles query processing using facts and Claude API
 type Processor struct {
-	client       *claude.Client
-	chunkManager *ChunkManager
-	facts        []models.ExtractedFact
-	onProgress   ProgressCallback
+	client              *claude.Client
+	chunkManager        *ChunkManager
+	facts               []models.ExtractedFact
+	onProgress          ProgressCallback
+	conversationHistory []ConversationTurn
 }
 
 // SetProgressCallback sets the callback for progress updates
 func (p *Processor) SetProgressCallback(cb ProgressCallback) {
 	p.onProgress = cb
+}
+
+// SetConversationHistory provides prior Q&A turns so follow-up questions can reference earlier context
+func (p *Processor) SetConversationHistory(history []ConversationTurn) {
+	p.conversationHistory = history
 }
 
 // NewProcessor creates a new query processor
@@ -252,6 +264,21 @@ func (p *Processor) selectRelevantFactsWithLLM(ctx context.Context, query string
 func (p *Processor) evaluateFactBatch(ctx context.Context, query string, startIdx, endIdx int) ([]int, error) {
 	var sb strings.Builder
 	sb.WriteString("You are analyzing extracted facts from compliance/audit documents to find ones relevant to a user's question.\n\n")
+
+	// Include conversation history so follow-up questions can be understood in context
+	if len(p.conversationHistory) > 0 {
+		sb.WriteString("Conversation so far:\n")
+		for _, turn := range p.conversationHistory {
+			sb.WriteString(fmt.Sprintf("User: %s\n", turn.Query))
+			// Include a truncated answer to keep the prompt reasonable
+			answer := turn.Answer
+			if len(answer) > 300 {
+				answer = answer[:300] + "..."
+			}
+			sb.WriteString(fmt.Sprintf("Assistant: %s\n\n", answer))
+		}
+	}
+
 	sb.WriteString(fmt.Sprintf("Question: %s\n\n", query))
 	sb.WriteString("Think broadly about relevance. For example:\n")
 	sb.WriteString("- Questions about 'employee onboarding' relate to: hiring, background checks, training, orientation, access provisioning\n")
@@ -542,7 +569,18 @@ func (p *Processor) GenerateAnswerStream(ctx context.Context, query string, fact
 // buildAnswerPrompt builds the prompt for answer generation
 func (p *Processor) buildAnswerPrompt(query string, facts []models.ExtractedFact) string {
 	var sb strings.Builder
-	sb.WriteString("Based on the following extracted facts from official documents, answer this question:\n\n")
+	sb.WriteString("Based on the following extracted facts from official documents, answer this question.\n\n")
+
+	// Include conversation history so follow-up questions make sense
+	if len(p.conversationHistory) > 0 {
+		sb.WriteString("Conversation so far:\n")
+		for _, turn := range p.conversationHistory {
+			sb.WriteString(fmt.Sprintf("User: %s\n", turn.Query))
+			sb.WriteString(fmt.Sprintf("Assistant: %s\n\n", turn.Answer))
+		}
+		sb.WriteString("Now answer the follow-up question using the facts below.\n\n")
+	}
+
 	sb.WriteString(fmt.Sprintf("Question: %s\n\n", query))
 	sb.WriteString("Available Facts:\n")
 


### PR DESCRIPTION
Pass prior Q&A turns to the query processor so follow-up questions can reference earlier conversation context during fact selection and answer generation.



Ai-assisted: true